### PR TITLE
Only set remote-debugging-port on adapter runtime, if it shares runtime with the app

### DIFF
--- a/openfin-csharp-api-test/openfin-csharp-api-test/OpenfinTests.cs
+++ b/openfin-csharp-api-test/openfin-csharp-api-test/OpenfinTests.cs
@@ -20,6 +20,11 @@ namespace OpenfinDesktop
         private const string OPENFIN_ADAPTER_RUNTIME = "14.78.46.23";
         private string OPENFIN_APP_RUNTIME = "";
 
+        private bool shareRuntime
+        {
+            get => OPENFIN_APP_RUNTIME == OPENFIN_ADAPTER_RUNTIME;
+        }
+
         private const int FILE_SERVER_PORT = 9070;
         private const int REMOTE_DEBUGGING_PORT = 4444;
 
@@ -53,7 +58,7 @@ namespace OpenfinDesktop
 
             string runOpenfinPath = Path.Combine(dir, "RunOpenFin.bat");
             string appConfigArg = String.Format("--config={0}", APP_CONFIG_URL);
-            if (runtime != null)
+            if (shareRuntime && runtime != null)
             {
                 options.DebuggerAddress = "localhost:4444";
                 Process.Start(runOpenfinPath, appConfigArg);
@@ -72,7 +77,7 @@ namespace OpenfinDesktop
 
             RuntimeOptions options = new RuntimeOptions();
             options.Version = OPENFIN_ADAPTER_RUNTIME;
-            options.Arguments = String.Format("--remote-debugging-port={0}", REMOTE_DEBUGGING_PORT);
+            options.Arguments = shareRuntime ? String.Format("--remote-debugging-port={0}", REMOTE_DEBUGGING_PORT) : "";
             runtime = Openfin.Desktop.Runtime.GetRuntimeInstance(options);
             runtime.Connect(() =>
             {

--- a/openfin-csharp-api-test/openfin-csharp-api-test/OpenfinTests.cs
+++ b/openfin-csharp-api-test/openfin-csharp-api-test/OpenfinTests.cs
@@ -17,7 +17,8 @@ namespace OpenfinDesktop
     {
         private const string OPENFIN_APP_UUID = "openfin-tests";
 
-        private const string OPENFIN_ADAPTER_RUNTIME = "14.78.46.23"; // OpenFin app runtime is defined in app.json
+        private const string OPENFIN_ADAPTER_RUNTIME = "14.78.46.23";
+        private string OPENFIN_APP_RUNTIME = "";
 
         private const int FILE_SERVER_PORT = 9070;
         private const int REMOTE_DEBUGGING_PORT = 4444;
@@ -34,6 +35,8 @@ namespace OpenfinDesktop
             string dirToServe = Path.Combine(dir, "../../../../src");
             // Serve OpenFin app assets
             fileServer = new HttpFileServer(dirToServe, FILE_SERVER_PORT);
+            RuntimeOptions appOptions = RuntimeOptions.LoadManifest(new Uri("http://localhost:9070/app.json"));
+            OPENFIN_APP_RUNTIME = appOptions.Version;
         }
 
         public void StartOpenfinApp()

--- a/openfin-csharp-api-test/openfin-csharp-api-test/OpenfinTests.cs
+++ b/openfin-csharp-api-test/openfin-csharp-api-test/OpenfinTests.cs
@@ -23,6 +23,8 @@ namespace OpenfinDesktop
         private const int FILE_SERVER_PORT = 9070;
         private const int REMOTE_DEBUGGING_PORT = 4444;
 
+        private readonly string APP_CONFIG_URL = String.Format("http://localhost:{0}/app.json", FILE_SERVER_PORT);
+
         ChromeDriver driver;
         HttpFileServer fileServer;
 
@@ -35,7 +37,7 @@ namespace OpenfinDesktop
             string dirToServe = Path.Combine(dir, "../../../../src");
             // Serve OpenFin app assets
             fileServer = new HttpFileServer(dirToServe, FILE_SERVER_PORT);
-            RuntimeOptions appOptions = RuntimeOptions.LoadManifest(new Uri("http://localhost:9070/app.json"));
+            RuntimeOptions appOptions = RuntimeOptions.LoadManifest(new Uri(APP_CONFIG_URL));
             OPENFIN_APP_RUNTIME = appOptions.Version;
         }
 
@@ -50,7 +52,7 @@ namespace OpenfinDesktop
             var options = new ChromeOptions();
 
             string runOpenfinPath = Path.Combine(dir, "RunOpenFin.bat");
-            string appConfigArg = String.Format("--config=http://localhost:{0}/app.json", FILE_SERVER_PORT);
+            string appConfigArg = String.Format("--config={0}", APP_CONFIG_URL);
             if (runtime != null)
             {
                 options.DebuggerAddress = "localhost:4444";


### PR DESCRIPTION
Only set remote-debugging-port on adapter runtime, if it shares runtime with the app