### PR TITLE
Test getProcessList

### DIFF
--- a/openfin-csharp-api-test/openfin-csharp-api-test/OpenfinTests.cs
+++ b/openfin-csharp-api-test/openfin-csharp-api-test/OpenfinTests.cs
@@ -28,7 +28,8 @@ namespace OpenfinDesktop
         private const int FILE_SERVER_PORT = 9070;
         private const int REMOTE_DEBUGGING_PORT = 4444;
 
-        private readonly string APP_CONFIG_URL = String.Format("http://localhost:{0}/app.json", FILE_SERVER_PORT);
+        private static readonly string FILE_SERVER_ROOT_URL = String.Format("http://localhost:{0}/", FILE_SERVER_PORT);
+        private static readonly string APP_CONFIG_URL = FILE_SERVER_ROOT_URL + "app.json";
 
         ChromeDriver driver;
         HttpFileServer fileServer;
@@ -236,7 +237,7 @@ namespace OpenfinDesktop
 
             Assert.Greater(workingSetSize, 10000000, "working set at least 10MB");
 
-            string returnLocationScript = String.Format("window.location = 'http://localhost:{0}/index.html'", FILE_SERVER_PORT);
+            string returnLocationScript = String.Format("window.location = '{0}index.html'", FILE_SERVER_ROOT_URL);
             driver.ExecuteScript(returnLocationScript);
 
             processInfo = getProcessInfo();

--- a/openfin-csharp-api-test/openfin-csharp-api-test/OpenfinTests.cs
+++ b/openfin-csharp-api-test/openfin-csharp-api-test/OpenfinTests.cs
@@ -221,7 +221,7 @@ namespace OpenfinDesktop
         }
 
         [Test]
-        public void GetProcessList()
+        public async Task GetProcessList()
         {
             StartOpenfinApp();
 
@@ -231,6 +231,7 @@ namespace OpenfinDesktop
             Assert.Greater(origWorkingSetSize, 10000000, "working set at least 10MB");
 
             driver.ExecuteScript("window.location = 'http://www.google.co.uk'");
+            await Task.Delay(2000);
 
             processInfo = getProcessInfo();
             long workingSetSize = (long)processInfo["workingSetSize"];
@@ -239,6 +240,7 @@ namespace OpenfinDesktop
 
             string returnLocationScript = String.Format("window.location = '{0}index.html'", FILE_SERVER_ROOT_URL);
             driver.ExecuteScript(returnLocationScript);
+            await Task.Delay(2000);
 
             processInfo = getProcessInfo();
             workingSetSize = (long)processInfo["workingSetSize"];


### PR DESCRIPTION
`getProcessList()` returns incorrect values after changing `window.location`
This test isn't perfect as it occasionally passes.