### PR TITLE
Launch tests using openfin-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@ nunit tests for testing the parts of OpenFin framework that we depend on.
 
 OpenFin provide a (pretty inactive) project demonstrating running tests in JavaScript (https://github.com/openfin/hello-openfin-selenium-example)
 
+## Requirements
+### openfin-cli
+```
+npm install -g openfin-cli
+```
+
 ## Testing runtimes
 ### Selenium.WebDriver.ChromeDriver
 The version of Selenium.WebDriver.ChromeDriver needs to match the version of Chrome used by the OpenFin runtime defined in app.json

--- a/openfin-csharp-api-test/openfin-csharp-api-test/RunOpenFin.bat
+++ b/openfin-csharp-api-test/openfin-csharp-api-test/RunOpenFin.bat
@@ -32,6 +32,5 @@ echo Debugging port: %debuggingPort%
 SET openfinLocation=%LocalAppData%\OpenFin
 c:
 cd %openfinLocation%
-OpenFinRVM.exe --config=%startupURL% --runtime-arguments="--remote-debugging-port=%debuggingPort%"
-
+openfin -l -c %startupURL%
 ENDLOCAL

--- a/src/app.json
+++ b/src/app.json
@@ -8,7 +8,7 @@
     "autoShow": true
   },
   "runtime": {
-    "arguments": "",
+    "arguments": "--remote-debugging-port=4444",
     "version": "14.78.46.23"
   },
   "shortcut": {


### PR DESCRIPTION
This allows tests to be run consecutively in one run rather than individually.
`openfin-cli` doesn't support passing --runtime-arguments