### PR TITLE
Ensure that Openfin app and adapter runtimes are installed

### DIFF
--- a/openfin-csharp-api-test/openfin-csharp-api-test/OpenfinHelpers.cs
+++ b/openfin-csharp-api-test/openfin-csharp-api-test/OpenfinHelpers.cs
@@ -1,0 +1,47 @@
+﻿using Openfin.Desktop;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OpenfinDesktop
+{
+    class OpenfinHelpers
+    {
+        public static Task<Runtime> ConnectToRuntime(string version, string arguments = "")
+        {
+            var taskCompletionSource = new TaskCompletionSource<Runtime>();
+
+            RuntimeOptions options = new RuntimeOptions();
+            options.Version = version;
+            options.Arguments = arguments;
+            Runtime runtime = Runtime.GetRuntimeInstance(options);
+            runtime.Connect(() =>
+            {
+                taskCompletionSource.SetResult(runtime);
+            });
+
+            return taskCompletionSource.Task;
+        }
+
+        public static Task DisconnectFromRuntime(Runtime runtime)
+        {
+            var taskCompletionSource = new TaskCompletionSource<bool>();
+
+            if (runtime != null && runtime.IsConnected)
+            {
+                runtime.Disconnect(() =>
+                {
+                    taskCompletionSource.SetResult(true);
+                });
+            }
+            else
+            {
+                taskCompletionSource.SetResult(true);
+            }
+
+            return taskCompletionSource.Task;
+        }
+    }
+}

--- a/openfin-csharp-api-test/openfin-csharp-api-test/OpenfinTests.cs
+++ b/openfin-csharp-api-test/openfin-csharp-api-test/OpenfinTests.cs
@@ -17,8 +17,8 @@ namespace OpenfinDesktop
     {
         private const string OPENFIN_APP_UUID = "openfin-tests";
 
-        private const string OPENFIN_ADAPTER_RUNTIME = "14.78.46.23";
-        private string OPENFIN_APP_RUNTIME = "";
+        public const string OPENFIN_ADAPTER_RUNTIME = "14.78.46.23";
+        public string OPENFIN_APP_RUNTIME = "";
 
         private bool shareRuntime
         {
@@ -72,39 +72,13 @@ namespace OpenfinDesktop
             driver = new ChromeDriver(service, options);
         }
 
-        private Task<Runtime> ConnectToRuntime()
+        private async Task<Runtime> ConnectToRuntime()
         {
-            var taskCompletionSource = new TaskCompletionSource<Runtime>();
+            String arguments = shareRuntime ? String.Format("--remote-debugging-port={0}", REMOTE_DEBUGGING_PORT) : "";
 
-            RuntimeOptions options = new RuntimeOptions();
-            options.Version = OPENFIN_ADAPTER_RUNTIME;
-            options.Arguments = shareRuntime ? String.Format("--remote-debugging-port={0}", REMOTE_DEBUGGING_PORT) : "";
-            runtime = Openfin.Desktop.Runtime.GetRuntimeInstance(options);
-            runtime.Connect(() =>
-            {
-                taskCompletionSource.SetResult(runtime);
-            });
+            runtime = await OpenfinHelpers.ConnectToRuntime(OPENFIN_ADAPTER_RUNTIME, arguments);
 
-            return taskCompletionSource.Task;
-        }
-
-        private Task<Runtime> DisconnectFromRuntime()
-        {
-            var taskCompletionSource = new TaskCompletionSource<Runtime>();
-
-            if (runtime != null && runtime.IsConnected)
-            {
-                runtime.Disconnect(() =>
-                {
-                    taskCompletionSource.SetResult(runtime);
-                });
-            }
-            else
-            {
-                taskCompletionSource.SetResult(runtime);
-            }
-
-            return taskCompletionSource.Task;
+            return runtime;
         }
 
         private async Task<Application> GetApplication(string UUID)
@@ -270,7 +244,7 @@ namespace OpenfinDesktop
 
             StopOpenfinApp();
 
-            await DisconnectFromRuntime();
+            await OpenfinHelpers.DisconnectFromRuntime(runtime);
         }
     }
 }

--- a/openfin-csharp-api-test/openfin-csharp-api-test/Program.cs
+++ b/openfin-csharp-api-test/openfin-csharp-api-test/Program.cs
@@ -1,9 +1,26 @@
-﻿namespace OpenfinDesktop
+﻿using Openfin.Desktop;
+using System.Threading.Tasks;
+
+namespace OpenfinDesktop
 {
     class Program
     {
+        static async Task EnsureRuntimes()
+        {
+            OpenfinTests openfinTests = new OpenfinTests();
+            openfinTests.SetUp();
+            Runtime runtime = await OpenfinHelpers.ConnectToRuntime(openfinTests.OPENFIN_APP_RUNTIME);
+            await OpenfinHelpers.DisconnectFromRuntime(runtime);
+            if (OpenfinTests.OPENFIN_ADAPTER_RUNTIME != openfinTests.OPENFIN_APP_RUNTIME)
+            {
+                await OpenfinHelpers.ConnectToRuntime(OpenfinTests.OPENFIN_ADAPTER_RUNTIME);
+            }
+        }
+
         static void Main(string[] args)
         {
+            var task = Task.Run(async () => { await EnsureRuntimes(); });
+            task.Wait();
         }
     }
 }

--- a/openfin-csharp-api-test/openfin-csharp-api-test/openfin-csharp-api-test.csproj
+++ b/openfin-csharp-api-test/openfin-csharp-api-test/openfin-csharp-api-test.csproj
@@ -46,6 +46,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="HttpFileServer.cs" />
+    <Compile Include="OpenfinHelpers.cs" />
     <Compile Include="OpenfinTests.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
Running `Main` will ensure that the required Openfin runtimes are installed.
It will also install OpenfinRVM, if missing.