### PR TITLE
TL-714 - Wait (and switch to) main window after starting app

### DIFF
--- a/openfin-csharp-api-test/openfin-csharp-api-test/OpenfinTests.cs
+++ b/openfin-csharp-api-test/openfin-csharp-api-test/OpenfinTests.cs
@@ -29,6 +29,8 @@ namespace OpenfinDesktop
 
         private static readonly string FILE_SERVER_ROOT_URL = String.Format("http://localhost:{0}/", FILE_SERVER_PORT);
         private static readonly string APP_CONFIG_URL = FILE_SERVER_ROOT_URL + "app.json";
+        private static readonly string MAIN_WINDOW_URL = FILE_SERVER_ROOT_URL + "index.html";
+
 
         ChromeDriver driver;
         HttpFileServer fileServer;
@@ -398,7 +400,18 @@ await platform.applySnapshot(snapshot);
             WindowIsEventuallyOpen(app, APP_WINDOW_LOAD_TIMEOUT_MS).Wait();
         }
 
-        private async Task<bool> WindowIsEventuallyOpen(Application app, int timeout)
+        private bool SwitchToMainWindow()
+        {
+            int index = 0;
+            while (driver.Url != MAIN_WINDOW_URL && index < driver.WindowHandles.Count)
+            {
+                driver.SwitchTo().Window(driver.WindowHandles[index]);
+                index++;
+            }
+            return driver.Url == MAIN_WINDOW_URL;
+        }
+
+        private async Task<bool> MainWindowIsEventuallyOpen(int timeout)
         {
             return await IsEventually(() =>
             {


### PR DESCRIPTION
On start up the driver automatically connects to a window which is not the main (visible) window.
Up until 26.102.71.10 this looked like the provider window
From 27.104.71.17 it is about:blank

This means that calling `window.close()` using `ExecuteScript` had no effect (app didn't close) and so tests failed.

Switching to the main tab means that tests can close the app as expected.

With these changes, all tests run against 34.118.78.83 (as long as both the app and adapter are on same version)
It looks like cross runtime compatibility is still an issue as events (App.Started) didn't fire with the app on 34.118.78.83 and the adapter on 19.89.59.24.
Fortunately this is no longer a problem for us, as the add-in automatically uses the same runtime as the terminal app.